### PR TITLE
Define the IntoIterator traits on the CS types

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -1,8 +1,8 @@
 use serde::de;
 use serde::ser;
 
-use std::fmt;
 use std::str::FromStr;
+use std::{array, fmt};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CS<T, const N: usize>(pub [T; N]);
@@ -51,6 +51,15 @@ impl<T: FromStr + Default + Copy, const N: usize> FromStr for CS<T, N> {
             *entry = s.parse()?;
         }
         Ok(arr)
+    }
+}
+
+impl<T, const N: usize> IntoIterator for CS<T, N> {
+    type Item = T;
+    type IntoIter = array::IntoIter<T, N>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,8 +1,8 @@
 use serde::de;
 use serde::ser;
 
-use std::fmt;
 use std::str::FromStr;
+use std::{fmt, vec};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CS<T>(pub Vec<T>);
@@ -47,6 +47,15 @@ impl<T: FromStr> FromStr for CS<T> {
             .map(T::from_str)
             .collect::<Result<Vec<_>, _>>()
             .map(Self)
+    }
+}
+
+impl<T> IntoIterator for CS<T> {
+    type Item = T;
+    type IntoIter = vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 


### PR DESCRIPTION
I found it useful to declare [the `IntoIterator` trait](https://doc.rust-lang.org/nightly/std/iter/trait.IntoIterator.html) on these two `CS` types, I no more need to call `.into_inner().into_iter()` and can pass this `CS` type to any function accepting an `IntoIterator<Item = T>` instead of converting it.

However, [the array implementation of `IntoIterator` that returned owned types](https://doc.rust-lang.org/nightly/std/primitive.array.html#impl-IntoIterator-2) is quite recent and has been released in the 1.53 version of Rust, I don't know if we want to bump the MSRV of this crate and if we don't: how can we make it conditional to the version of Rust the user is using.